### PR TITLE
Fix instructions for kind

### DIFF
--- a/content/en/docs/Tutorials/deploy-kind.md
+++ b/content/en/docs/Tutorials/deploy-kind.md
@@ -117,9 +117,6 @@ services:
   router:
     externalIPs:
     - ${node_ip}
-kube:
-  service_cluster_ip_range: 0.0.0.0/0
-  pod_cluster_ip_range: 0.0.0.0/0
 _EOF_
 ```
 
@@ -131,6 +128,8 @@ lines into your **values.yaml** file:
 features:
   eirini:
     enabled: true
+
+install_stacks: ["sle15"]
 ...
 ```
 


### PR DESCRIPTION
With the latest kubecf release, the instructions result in a non working Eirini deployment but I don't know why yet. I opened an issue in kubecf for that: https://github.com/cloudfoundry-incubator/kubecf/issues/1549