### PR TITLE
Kind tutorial snippets not reflecting the script

### DIFF
--- a/content/en/docs/Tutorials/deploy-kind.md
+++ b/content/en/docs/Tutorials/deploy-kind.md
@@ -150,10 +150,6 @@ services:
   router:
     externalIPs:
     - 172.17.0.3
-
-kube:
-  service_cluster_ip_range: 0.0.0.0/0
-  pod_cluster_ip_range: 0.0.0.0/0
 ```
 
 Now is time to install KubeCF by running the helm command:

--- a/content/en/docs/Tutorials/deploy-kind.md
+++ b/content/en/docs/Tutorials/deploy-kind.md
@@ -148,7 +148,7 @@ system_domain: 172.17.0.3.nip.io
 
 services:
   router:
-    loadBalancerIP:
+    externalIPs:
     - 172.17.0.3
 
 kube:


### PR DESCRIPTION
```
system_domain: 172.17.0.3.nip.io

services:
  router:
    loadBalancerIP:
    - 172.17.0.3

kube:
  service_cluster_ip_range: 0.0.0.0/0
  pod_cluster_ip_range: 0.0.0.0/0
```


If i follow the snippet example, i get the following error
```
helm install kubecf \
    --namespace kubecf \
    --values values.yaml \
    ./kubecf_release.tgz          
Error: values don't meet the specifications of the schema(s) in the following chart(s):
kubecf:
- kube: Additional property pod_cluster_ip_range is not allowed
- kube: Additional property service_cluster_ip_range is not allowed
- services.router.loadBalancerIP: Must validate at least one schema (anyOf)
- services.router.loadBalancerIP: Invalid type. Expected: string, given: array
- services.router: Must validate all the schemas (allOf)
```

and with 
```
kube:
  service_cluster_ip_range: 0.0.0.0/0
  pod_cluster_ip_range: 0.0.0.0/0
```

I get:

```
Error: values don't meet the specifications of the schema(s) in the following chart(s):
kubecf:
- kube: Additional property pod_cluster_ip_range is not allowed
- kube: Additional property service_cluster_ip_range is not allowed
```